### PR TITLE
Use trusty environment - closes #5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - '5.4'
   - '5.5'


### PR DESCRIPTION
This PR sets the environment to `trusty` again so that we can use PHP 5.4 and 5.5 there.